### PR TITLE
Fix OpenCut description text

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -371,7 +371,7 @@ const initialLinks = [
     url: 'https://github.com/OpenCut-app/OpenCut',
     mainCategory: 'github',
     subCategory: '工具类',
-    description: 'OpenCut 开源的视屏剪辑工具',
+    description: 'OpenCut 开源的视频剪辑工具',
     rating: 7,
   },{
     id:41,


### PR DESCRIPTION
## Summary
- fix Chinese text for OpenCut description

## Testing
- `npm run lint` *(fails: cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6867a6366f40832980e20cb17b18674d

## Summary by Sourcery

Bug Fixes:
- Correct the OpenCut description from ‘视屏剪辑工具’ to ‘视频剪辑工具’.